### PR TITLE
fix: meshkit package mismatch

### DIFF
--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run utility
         run: |
-          go run github.com/meshery/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers
+          go run github.com/layer5io/meshkit/cmd/errorutil -d . update --skip-dirs meshery -i ./helpers -o ./helpers
       # to update errorutil* files in meshkit repo
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
**Description**

This PR fixes #

- due to `errorutil` package mismatch workflow might be failing (error logs not accessible for the last run workflow)

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

